### PR TITLE
edwards25519: outline (*Point).Bytes

### DIFF
--- a/edwards25519.go
+++ b/edwards25519.go
@@ -135,7 +135,7 @@ func (v *Point) bytes(buf *[32]byte) []byte {
 
 	out := y.bytes(buf)
 	out[31] |= byte(x.IsNegative() << 7)
-	return out[:]
+	return out
 }
 
 // SetBytes sets v = x, where x is a 32 bytes encoding of v. If x does not

--- a/edwards25519.go
+++ b/edwards25519.go
@@ -121,14 +121,21 @@ func (v *Point) Set(u *Point) *Point {
 // Bytes returns the canonical 32 bytes encoding of v, according to RFC 8032,
 // Section 5.1.2.
 func (v *Point) Bytes() []byte {
+	// This function is outlined to make the allocations inline in the caller
+	// rather than happen on the heap.
+	var buf [32]byte
+	return v.bytes(&buf)
+}
+
+func (v *Point) bytes(buf *[32]byte) []byte {
 	var recip, x, y fieldElement
 	recip.Invert(&v.z)
 	x.Multiply(&v.x, &recip) // x = X / Z
 	y.Multiply(&v.y, &recip) // y = Y / Z
 
-	out := y.Bytes()
+	out := y.bytes(buf)
 	out[31] |= byte(x.IsNegative() << 7)
-	return out
+	return out[:]
 }
 
 // SetBytes sets v = x, where x is a 32 bytes encoding of v. If x does not


### PR DESCRIPTION
`(*fieldElement).Bytes()` uses the inlining trick to punt its allocation up to the caller. `(*Point).Bytes` calls `(*fieldElement).Bytes()`, but `(*Point).Bytes` is itself too large to be inlined, so the caller of `(*Point).Bytes` incurs a heap allocation. This PR outlines `(*Point).bytes`, allowing the caller to (potentially) avoid the allocation.