### PR TITLE
10% perf improvement with a little arm64 assembly and laxer limb bounds

### DIFF
--- a/fe.go
+++ b/fe.go
@@ -51,19 +51,14 @@ func (v *fieldElement) One() *fieldElement {
 	return v
 }
 
-// carryPropagate brings the limbs below 52, 51, 51, 51, 51 bits. It is split in
-// two because of the inliner heuristics. The two functions MUST be called one
-// after the other.
-func (v *fieldElement) carryPropagate1() *fieldElement {
+// carryPropagate brings the limbs below 52, 51, 51, 51, 51 bits.
+func (v *fieldElement) carryPropagate() *fieldElement {
 	v.l1 += v.l0 >> 51
 	v.l0 &= maskLow51Bits
 	v.l2 += v.l1 >> 51
 	v.l1 &= maskLow51Bits
 	v.l3 += v.l2 >> 51
 	v.l2 &= maskLow51Bits
-	return v
-}
-func (v *fieldElement) carryPropagate2() *fieldElement {
 	v.l4 += v.l3 >> 51
 	v.l3 &= maskLow51Bits
 	v.l0 += (v.l4 >> 51) * 19
@@ -73,7 +68,7 @@ func (v *fieldElement) carryPropagate2() *fieldElement {
 
 // reduce reduces v modulo 2^255 - 19 and returns it.
 func (v *fieldElement) reduce() *fieldElement {
-	v.carryPropagate1().carryPropagate2()
+	v.carryPropagate()
 
 	// After the light reduction we now have a field element representation
 	// v < 2^255 + 2^13 * 19, but need v < 2^255 - 19.
@@ -111,7 +106,7 @@ func (v *fieldElement) Add(a, b *fieldElement) *fieldElement {
 	v.l2 = a.l2 + b.l2
 	v.l3 = a.l3 + b.l3
 	v.l4 = a.l4 + b.l4
-	return v.carryPropagate1().carryPropagate2()
+	return v.carryPropagate()
 }
 
 // Subtract sets v = a - b, and returns v.
@@ -123,7 +118,7 @@ func (v *fieldElement) Subtract(a, b *fieldElement) *fieldElement {
 	v.l2 = (a.l2 + 0xFFFFFFFFFFFFE) - b.l2
 	v.l3 = (a.l3 + 0xFFFFFFFFFFFFE) - b.l3
 	v.l4 = (a.l4 + 0xFFFFFFFFFFFFE) - b.l4
-	return v.carryPropagate1().carryPropagate2()
+	return v.carryPropagate()
 }
 
 // Negate sets v = -a, and returns v.

--- a/fe.go
+++ b/fe.go
@@ -21,8 +21,7 @@ type fieldElement struct {
 	// An element t represents the integer
 	//     t.l0 + t.l1*2^51 + t.l2*2^102 + t.l3*2^153 + t.l4*2^204
 	//
-	// Between operations, all limbs are expected to be lower than 2^51, except
-	// l0, which can be up to 2^51 + 2^13 * 19 due to carry propagation.
+	// Between operations, all limbs are expected to be lower than 2^52.
 	l0 uint64
 	l1 uint64
 	l2 uint64

--- a/fe_amd64.go
+++ b/fe_amd64.go
@@ -11,3 +11,7 @@ func feMul(out, a, b *fieldElement)
 
 //go:noescape
 func feSquare(out, x *fieldElement)
+
+func (v *fieldElement) carryPropagate() *fieldElement {
+	return v.carryPropagateGeneric()
+}

--- a/fe_arm64.go
+++ b/fe_arm64.go
@@ -1,8 +1,8 @@
-// Copyright (c) 2019 The Go Authors. All rights reserved.
+// Copyright (c) 2020 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64,!arm64 !gc purego
+// +build arm64,gc,!purego
 
 package edwards25519
 
@@ -10,6 +10,10 @@ func feMul(v, x, y *fieldElement) { feMulGeneric(v, x, y) }
 
 func feSquare(v, x *fieldElement) { feSquareGeneric(v, x) }
 
+//go:noescape
+func carryPropagate(v *fieldElement)
+
 func (v *fieldElement) carryPropagate() *fieldElement {
-	return v.carryPropagateGeneric()
+	carryPropagate(v)
+	return v
 }

--- a/fe_arm64.s
+++ b/fe_arm64.s
@@ -8,41 +8,29 @@
 
 // func carryPropagate(v *fieldElement)
 TEXT ·carryPropagate(SB),NOFRAME|NOSPLIT,$0-8
-	MOVD v+0(FP), R10
+	MOVD v+0(FP), R20
 
-	LDP 0(R10), (R0, R1)
-	LDP 16(R10), (R2, R3)
-	MOVD 32(R10), R4
+	LDP 0(R20), (R0, R1)
+	LDP 16(R20), (R2, R3)
+	MOVD 32(R20), R4
 
-	// v.l1 += v.l0 >> 51
-	// v.l0 &= maskLow51Bits
-	ADD R0>>51, R1, R1
-	AND $0x7ffffffffffff, R0, R0
+	AND $0x7ffffffffffff, R0, R10
+	AND $0x7ffffffffffff, R1, R11
+	AND $0x7ffffffffffff, R2, R12
+	AND $0x7ffffffffffff, R3, R13
+	AND $0x7ffffffffffff, R4, R14
 
-	// v.l2 += v.l1 >> 51
-	// v.l1 &= maskLow51Bits
-	ADD R1>>51, R2, R2
-	AND $0x7ffffffffffff, R1, R1
+	ADD R0>>51, R11, R11
+	ADD R1>>51, R12, R12
+	ADD R2>>51, R13, R13
+	ADD R3>>51, R14, R14
+	// R4>>51 * 19 + R10 -> R10
+	LSR $51, R4, R21
+	MOVD $19, R22
+	MADD R22, R10, R21, R10
 
-	// v.l3 += v.l2 >> 51
-	// v.l2 &= maskLow51Bits
-	ADD R2>>51, R3, R3
-	AND $0x7ffffffffffff, R2, R2
-
-	// v.l4 += v.l3 >> 51
-	// v.l3 &= maskLow51Bits
-	ADD R3>>51, R4, R4
-	AND $0x7ffffffffffff, R3, R3
-
-	// v.l0 += (v.l4 >> 51) * 19
-	// v.l4 &= maskLow51Bits
-	LSR $51, R4, R14
-	MOVD $19, R19
-	MADD R19, R0, R14, R0
-	AND $0x7ffffffffffff, R4, R4
-
-	STP (R0, R1), 0(R10)
-	STP (R2, R3), 16(R10)
-	MOVD R4, 32(R10)
+	STP (R10, R11), 0(R20)
+	STP (R12, R13), 16(R20)
+	MOVD R14, 32(R20)
 
 	RET

--- a/fe_arm64.s
+++ b/fe_arm64.s
@@ -1,0 +1,48 @@
+// Copyright (c) 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build arm64,gc,!purego
+
+#include "textflag.h"
+
+// func carryPropagate(v *fieldElement)
+TEXT ·carryPropagate(SB),NOFRAME|NOSPLIT,$0-8
+	MOVD v+0(FP), R10
+
+	LDP 0(R10), (R0, R1)
+	LDP 16(R10), (R2, R3)
+	MOVD 32(R10), R4
+
+	// v.l1 += v.l0 >> 51
+	// v.l0 &= maskLow51Bits
+	ADD R0>>51, R1, R1
+	AND $0x7ffffffffffff, R0, R0
+
+	// v.l2 += v.l1 >> 51
+	// v.l1 &= maskLow51Bits
+	ADD R1>>51, R2, R2
+	AND $0x7ffffffffffff, R1, R1
+
+	// v.l3 += v.l2 >> 51
+	// v.l2 &= maskLow51Bits
+	ADD R2>>51, R3, R3
+	AND $0x7ffffffffffff, R2, R2
+
+	// v.l4 += v.l3 >> 51
+	// v.l3 &= maskLow51Bits
+	ADD R3>>51, R4, R4
+	AND $0x7ffffffffffff, R3, R3
+
+	// v.l0 += (v.l4 >> 51) * 19
+	// v.l4 &= maskLow51Bits
+	LSR $51, R4, R14
+	MOVD $19, R19
+	MADD R19, R0, R14, R0
+	AND $0x7ffffffffffff, R4, R4
+
+	STP (R0, R1), 0(R10)
+	STP (R2, R3), 16(R10)
+	MOVD R4, 32(R10)
+
+	RET

--- a/fe_generic.go
+++ b/fe_generic.go
@@ -177,3 +177,18 @@ func feSquareGeneric(v, x *fieldElement) {
 	*v = fieldElement{r00, r10, r20, r30, r40}
 	v.carryPropagate()
 }
+
+// carryPropagate brings the limbs below 52, 51, 51, 51, 51 bits.
+func (v *fieldElement) carryPropagateGeneric() *fieldElement {
+	v.l1 += v.l0 >> 51
+	v.l0 &= maskLow51Bits
+	v.l2 += v.l1 >> 51
+	v.l1 &= maskLow51Bits
+	v.l3 += v.l2 >> 51
+	v.l2 &= maskLow51Bits
+	v.l4 += v.l3 >> 51
+	v.l3 &= maskLow51Bits
+	v.l0 += (v.l4 >> 51) * 19
+	v.l4 &= maskLow51Bits
+	return v
+}

--- a/fe_generic.go
+++ b/fe_generic.go
@@ -178,17 +178,20 @@ func feSquareGeneric(v, x *fieldElement) {
 	v.carryPropagate()
 }
 
-// carryPropagate brings the limbs below 52, 51, 51, 51, 51 bits.
+// carryPropagate brings the limbs below 52 bits by applying the reduction
+// identity to the l4 carry.
 func (v *fieldElement) carryPropagateGeneric() *fieldElement {
-	v.l1 += v.l0 >> 51
-	v.l0 &= maskLow51Bits
-	v.l2 += v.l1 >> 51
-	v.l1 &= maskLow51Bits
-	v.l3 += v.l2 >> 51
-	v.l2 &= maskLow51Bits
-	v.l4 += v.l3 >> 51
-	v.l3 &= maskLow51Bits
-	v.l0 += (v.l4 >> 51) * 19
-	v.l4 &= maskLow51Bits
+	c0 := v.l0 >> 51
+	c1 := v.l1 >> 51
+	c2 := v.l2 >> 51
+	c3 := v.l3 >> 51
+	c4 := v.l4 >> 51
+
+	v.l0 = v.l0&maskLow51Bits + c4*19
+	v.l1 = v.l1&maskLow51Bits + c0
+	v.l2 = v.l2&maskLow51Bits + c1
+	v.l3 = v.l3&maskLow51Bits + c2
+	v.l4 = v.l4&maskLow51Bits + c3
+
 	return v
 }

--- a/fe_generic.go
+++ b/fe_generic.go
@@ -101,7 +101,7 @@ func feMulGeneric(v, x, y *fieldElement) {
 	// finally from r_4 to r_0 . Each of these carries is done as one copy, one
 	// right shift by 51, one logical and with 2^51 − 1, and one addition.
 	*v = fieldElement{r00, r10, r20, r30, r40}
-	v.carryPropagate1().carryPropagate2()
+	v.carryPropagate()
 }
 
 func feSquareGeneric(v, x *fieldElement) {
@@ -175,5 +175,5 @@ func feSquareGeneric(v, x *fieldElement) {
 	r00 += r41
 
 	*v = fieldElement{r00, r10, r20, r30, r40}
-	v.carryPropagate1().carryPropagate2()
+	v.carryPropagate()
 }

--- a/fe_test.go
+++ b/fe_test.go
@@ -93,10 +93,10 @@ func (fieldElement) Generate(rand *mathrand.Rand, size int) reflect.Value {
 // after a light reduction.
 func isInBounds(x *fieldElement) bool {
 	return bits.Len64(x.l0) <= 52 &&
-		bits.Len64(x.l1) <= 51 &&
-		bits.Len64(x.l2) <= 51 &&
-		bits.Len64(x.l3) <= 51 &&
-		bits.Len64(x.l4) <= 51
+		bits.Len64(x.l1) <= 52 &&
+		bits.Len64(x.l2) <= 52 &&
+		bits.Len64(x.l3) <= 52 &&
+		bits.Len64(x.l4) <= 52
 }
 
 func TestMulDistributesOverAdd(t *testing.T) {
@@ -431,14 +431,6 @@ func TestSelectSwap(t *testing.T) {
 }
 
 func TestMul32(t *testing.T) {
-	isAlmostInBounds := func(x *fieldElement) bool {
-		return bits.Len64(x.l0) <= 52 &&
-			bits.Len64(x.l1) <= 52 &&
-			bits.Len64(x.l2) <= 52 &&
-			bits.Len64(x.l3) <= 52 &&
-			bits.Len64(x.l4) <= 52
-	}
-
 	mul32EquivalentToMul := func(x fieldElement, y uint32) bool {
 		t1 := new(fieldElement)
 		for i := 0; i < 100; i++ {
@@ -453,7 +445,7 @@ func TestMul32(t *testing.T) {
 			t2.Multiply(&x, ty)
 		}
 
-		return t1.Equal(t2) == 1 && isAlmostInBounds(t1) && isInBounds(t2)
+		return t1.Equal(t2) == 1 && isInBounds(t1) && isInBounds(t2)
 	}
 
 	if err := quick.Check(mul32EquivalentToMul, quickCheckConfig1024); err != nil {
@@ -537,5 +529,9 @@ func TestCarryPropagate(t *testing.T) {
 
 	if err := quick.Check(asmLikeGeneric, quickCheckConfig1024); err != nil {
 		t.Error(err)
+	}
+
+	if !asmLikeGeneric([5]uint64{0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff}) {
+		t.Errorf("failed for {0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff}")
 	}
 }

--- a/fe_test.go
+++ b/fe_test.go
@@ -519,3 +519,23 @@ func TestSqrtRatio(t *testing.T) {
 		}
 	}
 }
+
+func TestCarryPropagate(t *testing.T) {
+	asmLikeGeneric := func(a [5]uint64) bool {
+		t1 := &fieldElement{a[0], a[1], a[2], a[3], a[4]}
+		t2 := &fieldElement{a[0], a[1], a[2], a[3], a[4]}
+
+		t1.carryPropagate()
+		t2.carryPropagateGeneric()
+
+		if *t1 != *t2 {
+			t.Logf("got: %#v,\nexpected: %#v", t1, t2)
+		}
+
+		return *t1 == *t2 && isInBounds(t2)
+	}
+
+	if err := quick.Check(asmLikeGeneric, quickCheckConfig1024); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
```
name                    old time/op  new time/op  delta
Add-8                   7.17ns ± 1%  6.43ns ± 1%  -10.29%  (p=0.000 n=10+8)
Mul-8                   26.0ns ± 1%  24.6ns ± 1%   -5.40%  (p=0.000 n=10+10)
Mul32-8                 5.87ns ± 1%  5.87ns ± 1%     ~     (p=0.755 n=10+10)
WideMultCall-8          2.53ns ± 1%  2.54ns ± 0%     ~     (p=0.915 n=10+8)
BasepointMul-8          20.1µs ± 1%  18.7µs ± 1%   -6.94%  (p=0.000 n=9+10)
ScalarMul-8             71.6µs ± 0%  63.9µs ± 1%  -10.82%  (p=0.000 n=8+9)
VartimeDoubleBaseMul-8  68.7µs ± 1%  60.7µs ± 2%  -11.61%  (p=0.000 n=8+9)
MultiscalarMulSize8-8    246µs ± 2%   224µs ± 1%   -8.84%  (p=0.000 n=9+9)
```

@hdevalence @gtank, please check that I'm correct that everything works with 52 bit limbs, especially `reduce`?