### PR TITLE
edwards25519: fix ScalarMult when receiver is set

### DIFF
--- a/scalarmult.go
+++ b/scalarmult.go
@@ -78,6 +78,8 @@ func (v *Point) ScalarMult(x *Scalar, q *Point) *Point {
 	tmp1 := &projP1xP1{}
 	tmp2 := &projP2{}
 	table.SelectInto(multiple, digits[63])
+
+	v.Set(NewIdentityPoint())
 	tmp1.Add(v, multiple) // tmp1 = x_63*Q in P1xP1 coords
 	for i := 62; i >= 0; i-- {
 		tmp2.FromP1xP1(tmp1) // tmp2 =    (prev) in P2 coords

--- a/scalarmult_test.go
+++ b/scalarmult_test.go
@@ -93,6 +93,28 @@ func TestScalarMulDistributesOverAdd(t *testing.T) {
 	}
 }
 
+func TestScalarMulNonIdentityPoint(t *testing.T) {
+	// Check whether p.ScalarMult and q.ScalaBaseMult give the same,
+	// when p and q are originally set to the base point.
+
+	scalarMulNonIdentityPoint := func(x Scalar) bool {
+		var p, q Point
+		p.Set(B)
+		q.Set(B)
+
+		p.ScalarMult(&x, B)
+		q.ScalarBaseMult(&x)
+
+		checkOnCurve(t, &p, &q)
+
+		return p.Equal(&q) == 1
+	}
+
+	if err := quick.Check(scalarMulNonIdentityPoint, quickCheckConfig32); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestBasepointTableGeneration(t *testing.T) {
 	// The basepoint table is 32 affineLookupTables,
 	// corresponding to (16^2i)*B for table i.


### PR DESCRIPTION
Calling v.ScalarMult on a receiver v that is not the identity point results in an incorrect operation.
This was fixed by setting v to the identity point in ScalarMult.

A simple test was added to check this behavior.