### PR TITLE
scalar: expose a direct SetBytes

### DIFF
--- a/scalar.go
+++ b/scalar.go
@@ -152,6 +152,15 @@ func (s *Scalar) SetBytesWithClamping(x []byte) (*Scalar, error) {
 	return s, nil
 }
 
+// SetBytes directly sets the contents of the scalar. Use with caution.
+func (s *Scalar) SetBytes(x []byte) *Scalar {
+	if len(x) != 32 {
+		panic("edwards25519: invalid SetBytes input length")
+	}
+	copy(s.s[:], x[:])
+	return s
+}
+
 // Bytes returns the canonical 32-byte little-endian encoding of s.
 func (s *Scalar) Bytes() []byte {
 	buf := make([]byte, 32)

--- a/scalar.go
+++ b/scalar.go
@@ -153,12 +153,12 @@ func (s *Scalar) SetBytesWithClamping(x []byte) (*Scalar, error) {
 }
 
 // SetBytes directly sets the contents of the scalar. Use with caution.
-func (s *Scalar) SetBytes(x []byte) *Scalar {
+func (s *Scalar) SetBytes(x []byte) (*Scalar, error) {
 	if len(x) != 32 {
-		panic("edwards25519: invalid SetBytes input length")
+		return nil, errors.New("edwards25519: invalid SetBytes input length")
 	}
 	copy(s.s[:], x[:])
-	return s
+	return s, nil
 }
 
 // Bytes returns the canonical 32-byte little-endian encoding of s.


### PR DESCRIPTION
I was replacing github.com/agl/ed25519 with this package and crypto/ed25519 in a Go implementation of libsignal, but was unable to replace `edwards25519.GeScalarMultBase` without directly placing the private key bytes in a `Scalar` (https://github.com/tulir/libsignal-protocol-go/commit/37689eb21b79b11953fff44869dc21923ca49a8c)

This is mostly @tmc's code from https://github.com/tmc/edwards25519/tree/tmc-setbytes, I just updated it to return an error instead of panicking (like c1c1311e51373ad8c22b867b64fa68b2f62eed44 did for the existing setters).