### PR TITLE
Speed up BytesMontgomery

### DIFF
--- a/extra.go
+++ b/extra.go
@@ -100,13 +100,15 @@ func (v *Point) bytesMontgomery(buf *[32]byte) []byte {
 	//
 	//              u = (1 + y) / (1 - y)
 	//
-	// where y = Y / Z.
+	// where y = Y / Z and therefore
+	//
+	//              u = (Z + Y) / (Z - Y)
 
-	var y, recip, u field.Element
+	var n, r, u field.Element
 
-	y.Multiply(&v.y, y.Invert(&v.z))        // y = Y / Z
-	recip.Invert(recip.Subtract(feOne, &y)) // r = 1/(1 - y)
-	u.Multiply(u.Add(feOne, &y), &recip)    // u = (1 + y)*r
+	n.Add(&v.z, &v.y)                // n = Z + Y
+	r.Invert(r.Subtract(&v.z, &v.y)) // r = 1 / (Z - Y)
+	u.Multiply(&n, &r)               // u = n * r
 
 	return copyFieldElement(buf, &u)
 }

--- a/extra_test.go
+++ b/extra_test.go
@@ -218,3 +218,17 @@ func BenchmarkScalarInversion(b *testing.B) {
 		s1.Invert(s1)
 	}
 }
+
+func BenchmarkBytesMontgomery(b *testing.B) {
+	publicKey := "3bf918ffc2c955dc895bf145f566fb96623c1cadbe040091175764b5fde322c0"
+	p, err := (&Point{}).SetBytes(decodeHex(publicKey))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = p.BytesMontgomery()
+	}
+}


### PR DESCRIPTION
Speed up BytesMontgomery by eliminating Invert and Multiply.

```
goos: linux
goarch: amd64
pkg: filippo.io/edwards25519
cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
                  │   HEAD~1    │                HEAD                 │
                  │   sec/op    │   sec/op     vs base                │
BytesMontgomery-8   7.264µ ± 1%   3.670µ ± 0%  -49.48% (p=0.000 n=10)
```