### PR TITLE
field: fix Invert comment

### DIFF
--- a/field/fe.go
+++ b/field/fe.go
@@ -119,7 +119,7 @@ func (v *Element) Negate(a *Element) *Element {
 // If z == 0, Invert returns v = 0.
 func (v *Element) Invert(z *Element) *Element {
 	// Inversion is implemented as exponentiation with exponent p − 2. It uses the
-	// same sequence of 255 squarings and 11 multiplications as [Curve25519].
+	// same sequence of 254 squarings and 11 multiplications as [Curve25519].
 	var z2, z9, z11, z2_5_0, z2_10_0, z2_20_0, z2_50_0, z2_100_0, t Element
 
 	z2.Square(z)             // 2


### PR DESCRIPTION
[Curve25519: new Diffie-Hellman speed records](https://cr.yp.to/ecdh/curve25519-20060209.pdf) states that inverting an element is "a straightforward sequence of 254 squarings and 11 multiplications" which can also be verified by counting the number of [Element.Square] calls.

Fixes #39