### PR TITLE
field: speed up Element.Bytes

### DIFF
--- a/field/fe_bench_test.go
+++ b/field/fe_bench_test.go
@@ -47,3 +47,11 @@ func BenchmarkMult32(b *testing.B) {
 		x.Mult32(x, 0xaa42aa42)
 	}
 }
+
+func BenchmarkBytes(b *testing.B) {
+	x := new(Element).One()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		x.Bytes()
+	}
+}


### PR DESCRIPTION
Write bytes in 64-bit chunks made from adjacent limbs.
```
goos: linux
goarch: amd64
pkg: filippo.io/edwards25519/field
cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
        │   HEAD~1    │                HEAD                 │
        │   sec/op    │   sec/op     vs base                │
Bytes-8   60.31n ± 1%   13.67n ± 2%  -77.34% (p=0.000 n=10)

        │   HEAD~1   │              HEAD              │
        │    B/op    │    B/op     vs base            │
Bytes-8   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

        │   HEAD~1   │              HEAD              │
        │ allocs/op  │ allocs/op   vs base            │
Bytes-8   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```